### PR TITLE
Laravel 5 and jsonapi 1.0.0.rc2 specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v3.1.3
+------
+
+ 1. fixed bug preventing type property from being returned
+
+
+
 v3.1.2
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v2.0.0
+------
+
+ 1. Updated code and docs to support laravel 5.0
+ 2. Added basic support for sorting and filtering
+ 3. Updated POST response to return code 201 as specified in jsonapi specs
+
 v1.1.3
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+v3.0.1
+------
+
+ 1. Made linked resources include type property
+
 v3.0.0
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v3.0.0
+------
+
+ 1. Updated code and docs for basic support for jsonapi 1.0.0.rc2 specs
+ 2. Updated support for sorting to allow for multiple items and ascending/descending specifications
+ 3. Added validation of POST/PUT data
+
 v2.0.0
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+v3.1.2
+------
+
+ 1. Updated error response to include HTTP status code
+ 2. Updated phpunit tests
+ 3. Updated HTTP status returned from some exceptions to better match specs.
+
 v3.1.1
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 Changelog
 =========
 
+v3.1.4
+------
+
+ 1. Ran PHP-CS-Fixer on code to update to PSR-2 standards
+
 v3.1.3
 ------
 
  1. fixed bug preventing type property from being returned
-
 
 
 v3.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+v3.1.1
+------
+
+ 1. Updated readme and composer.json
+
 v3.1.0
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+v3.1.0
+------
+
+ 1. Added pagination support
+
 v3.0.1
 ------
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ class ApiController extends Controller
         if (class_exists($handlerClass)) {
             $method = Request::method();
             $include = ($i = Request::input('include')) ? explode(',', $i) : $i;
+            $sort = ($i = Request::input('sort')) ? explode(',', $i) : $i;
+	    $filter = ($i = Request::except('sort', 'include')) ? $i : [];
 
-            $request = new ApiRequest($method, $id, $include);
+            $request = new ApiRequest($method, $id, $include, $sort, $filter);
             $handler = new $handlerClass($request);
 
             // A handler can throw EchoIt\JsonApi\Exception which must be gracefully handled to give proper response
@@ -156,7 +158,8 @@ According to [jsonapi.org](http://jsonapi.org):
 * [Resource Relationships](http://jsonapi.org/format/#document-structure-resource-relationships)
    * Only through [Inclusion of Linked Resources](http://jsonapi.org/format/#fetching-includes)
 * [Compound Documents](http://jsonapi.org/format/#document-structure-compound-documents)
-
+* [Sorting](http://jsonapi.org/format/#fetching-sorting)
+* [Filtering](http://jsonapi.org/format/#fetching-filtering)
 
 Wishlist
 -----
@@ -165,5 +168,5 @@ Wishlist
 * [Resource URLs](http://jsonapi.org/format/#document-structure-resource-urls)
 * Requests for multiple [individual resources](http://jsonapi.org/format/#urls-individual-resources), e.g. `/users/1,2,3`
 * [Sparse Fieldsets](http://jsonapi.org/format/#fetching-sparse-fieldsets)
-* [Sorting](http://jsonapi.org/format/#fetching-sorting)
+
 * Some kind of caching mechanism

--- a/README.md
+++ b/README.md
@@ -90,56 +90,57 @@ class ApiController extends Controller
 use Symfony\Component\HttpFoundation\Response;
 use App\Models\User;
 
+use EchoIt\JsonApi\Exception as ApiException;
 use EchoIt\JsonApi\Request as ApiRequest;
 use EchoIt\JsonApi\Handler as ApiHandler;
 
 class UsersHandler extends ApiHandler
 {
-    const ERROR_SCOPE = 1024;
-	
+	const ERROR_SCOPE = 1024;
+
 	protected static $exposedRelations = [];
 
-    public function handleGet(ApiRequest $request)
-    {
-        if (empty($request->id)) {
-            return $this->handleGetAll($request);
-        }
+	public function handleGet(ApiRequest $request)
+	{
+		if (empty($request->id)) {
+			return $this->handleGetAll($request);
+		}
 
-        return User::find($request->id);
-    }
+		return User::find($request->id);
+	}
 
-    protected function handleGetAll(ApiRequest $request)
-    {
-        return User::all();
-    }
+	protected function handleGetAll(ApiRequest $request)
+	{
+		return User::all();
+	}
 
-    public function handlePut(ApiRequest $request)
-    {
-        if (empty($request->id)) {
-            throw new EchoIt\JsonApi\Exception(
-                'No ID provided',
-                static::ERROR_SCOPE | static::ERROR_NO_ID,
-                Response::HTTP_BAD_REQUEST
-            );
-        }
+	public function handlePut(ApiRequest $request)
+	{
+		if (empty($request->id)) {
+			throw new ApiException(
+				'No ID provided',
+				static::ERROR_SCOPE | static::ERROR_NO_ID,
+				Response::HTTP_BAD_REQUEST
+			);
+		}
 
-        $updates = \Input::json('users');
-        $user = User::find($request->id);
+		$updates = Request::json('users');
+		$user = User::find($request->id);
 
-        if (is_null($user)) return null;
+		if (is_null($user)) return null;
 
-        $user->fill($updates);
+		$user->fill($updates[0]);
 
-        if ( ! $user->save()) {
-            throw new EchoIt\JsonApi\Exception(
-                'An unknown error occurred',
-                static::ERROR_SCOPE | static::ERROR_UNKNOWN,
-                Response::HTTP_INTERNAL_SERVER_ERROR
-            );
-        }
+		if (!$user->save()) {
+			throw new ApiException(
+				'An unknown error occurred',
+				static::ERROR_SCOPE | static::ERROR_UNKNOWN,
+				Response::HTTP_INTERNAL_SERVER_ERROR
+			);
+		}
 
-        return $user;
-    }
+		return $user;
+	}
 }
     ```
 

--- a/README.md
+++ b/README.md
@@ -52,12 +52,14 @@ class ApiController extends Controller
         $handlerClass = 'App\\Handlers\\' . ucfirst($modelName) . 'Handler';
 
         if (class_exists($handlerClass)) {
+			$url = Request::url();
             $method = Request::method();
             $include = ($i = Request::input('include')) ? explode(',', $i) : $i;
-            $sort = ($i = Request::input('sort')) ? explode(',', $i) : $i;
-	    $filter = ($i = Request::except('sort', 'include')) ? $i : [];
+			$sort = ($i = Request::input('sort')) ? explode(',', $i) : $i;
+			$filter = ($i = Request::except('sort', 'include')) ? $i : [];
+			$content = Request::getContent();
 
-            $request = new ApiRequest($method, $id, $include, $sort, $filter);
+            $request = new ApiRequest($url, $method, $id, $content, $include, $sort, $filter);
             $handler = new $handlerClass($request);
 
             // A handler can throw EchoIt\JsonApi\Exception which must be gracefully handled to give proper response
@@ -66,8 +68,8 @@ class ApiController extends Controller
             } catch (ApiException $e) {
                 return $e->response();
             }
-
-            return $res->toJsonResponse(str_plural($modelName));
+			
+            return $res->toJsonResponse();
         }
 
         // If a handler class does not exist for requested model, it is not considered to be exposed in the API

--- a/README.md
+++ b/README.md
@@ -141,29 +141,28 @@ class UsersHandler extends ApiHandler
 	/**
 	 * Handles GET requests. 
 	 * @param EchoIt\JsonApi\Request $request
-	 * @return EchoIt\JsonApi\Model
+	 * @return EchoIt\JsonApi\Model|Illuminate\Support\Collection|EchoIt\JsonApi\Response|Illuminate\Pagination\LengthAwarePaginator
 	 */
 	public function handleGet(ApiRequest $request)
 	{
-		//use default GET functionality, which includes
-		//handling of sorting and filtering. 
+		//you can use the default GET functionality, or override with your own 
 		return $this->handleGetDefault($request, new User);
 	}
 	
 	/**
 	 * Handles PUT requests. 
 	 * @param EchoIt\JsonApi\Request $request
-	 * @return EchoIt\JsonApi\Model
+	 * @return EchoIt\JsonApi\Model|Illuminate\Support\Collection|EchoIt\JsonApi\Response
 	 */
 	public function handlePut(ApiRequest $request)
 	{
-		//use default PUT functionality
+		//you can use the default PUT functionality, or override with your own
 		return $this->handlePutDefault($request, new User);
 	}
 }
     ```
 
-    > **Note:** Extend your model from `EchoIt\JsonApi\Model` rather than `Eloquent` to get the proper response for linked resources.
+    > **Note:** Extend your models from `EchoIt\JsonApi\Model` rather than `Eloquent` to get the proper response for linked resources.
 
 Current features
 -----

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-JSON API helpers for Laravel 4
+JSON API helpers for Laravel 5
 =====
 
-Make it a breeze to create a [jsonapi.org](http://jsonapi.org/) compliant API with Laravel 4.
+Make it a breeze to create a [jsonapi.org](http://jsonapi.org/) compliant API with Laravel 5.
 
 Installation
 -----
@@ -11,7 +11,7 @@ Add `echo-it/laravel-jsonapi` to your composer.json dependency list and run `com
 ### Requirements
 
 * PHP 5.4+
-* Laravel 4 *(Tested with 4.2)*
+* Laravel 5
 
 
 Using laravel-jsonapi

--- a/README.md
+++ b/README.md
@@ -82,12 +82,14 @@ class ApiController extends Controller
 
     In this example we have create a handler which supports the following requests:
 
-    * GET /users
-    * GET /users/[id]
-    * PUT /users/[id]
+    * GET /users (ie. handleGet function)
+    * GET /users/[id] (ie. handleGet function)
+    * PUT /users/[id] (ie. handlePut function)
+    
+    Requests are automatically routed to appropriate handle functions.
 
     ```php
-    <?php namespace App\Handlers;
+<?php namespace App\Handlers;
 
 use Symfony\Component\HttpFoundation\Response;
 use App\Models\User;
@@ -95,53 +97,42 @@ use App\Models\User;
 use EchoIt\JsonApi\Exception as ApiException;
 use EchoIt\JsonApi\Request as ApiRequest;
 use EchoIt\JsonApi\Handler as ApiHandler;
+use Request;
 
+/**
+ * Handles API requests for Users.
+ */
 class UsersHandler extends ApiHandler
 {
 	const ERROR_SCOPE = 1024;
-
+	
+	/*
+	* List of relations that can be included in response.
+	* (eg. 'friend' could be included with ?include=friend)
+	*/
 	protected static $exposedRelations = [];
-
+	
+	/**
+	 * Handles GET requests. 
+	 * @param EchoIt\JsonApi\Request $request
+	 * @return EchoIt\JsonApi\Model
+	 */
 	public function handleGet(ApiRequest $request)
 	{
-		if (empty($request->id)) {
-			return $this->handleGetAll($request);
-		}
-
-		return User::find($request->id);
+		//use default GET functionality, which includes
+		//handling of sorting and filtering. 
+		return $this->handleGetDefault($request, new User);
 	}
-
-	protected function handleGetAll(ApiRequest $request)
-	{
-		return User::all();
-	}
-
+	
+	/**
+	 * Handles PUT requests. 
+	 * @param EchoIt\JsonApi\Request $request
+	 * @return EchoIt\JsonApi\Model
+	 */
 	public function handlePut(ApiRequest $request)
 	{
-		if (empty($request->id)) {
-			throw new ApiException(
-				'No ID provided',
-				static::ERROR_SCOPE | static::ERROR_NO_ID,
-				Response::HTTP_BAD_REQUEST
-			);
-		}
-
-		$updates = Request::json('users');
-		$user = User::find($request->id);
-
-		if (is_null($user)) return null;
-
-		$user->fill($updates[0]);
-
-		if (!$user->save()) {
-			throw new ApiException(
-				'An unknown error occurred',
-				static::ERROR_SCOPE | static::ERROR_UNKNOWN,
-				Response::HTTP_INTERNAL_SERVER_ERROR
-			);
-		}
-
-		return $user;
+		//use default PUT functionality
+		return $this->handlePutDefault($request, new User);
 	}
 }
     ```

--- a/README.md
+++ b/README.md
@@ -161,5 +161,6 @@ Wishlist
 * [Resource URLs](http://jsonapi.org/format/#document-structure-resource-urls)
 * Requests for multiple [individual resources](http://jsonapi.org/format/#urls-individual-resources), e.g. `/users/1,2,3`
 * [Sparse Fieldsets](http://jsonapi.org/format/#fetching-sparse-fieldsets)
+* [Pagination] (http://jsonapi.org/format/#fetching-pagination)
 
 * Some kind of caching mechanism

--- a/README.md
+++ b/README.md
@@ -6,7 +6,20 @@ Make it a breeze to create a [jsonapi.org](http://jsonapi.org/) compliant API wi
 Installation
 -----
 
-Add `echo-it/laravel-jsonapi` to your composer.json dependency list and run `composer update`.
+1. Add the github repo to your composer.json file:
+
+    ```
+    "repositories": [
+            {
+                "type": "vcs",
+                "url": "https://github.com/jpchip/laravel-jsonapi"
+            }
+    ]
+    ```
+
+2. Add `echo-it/laravel-jsonapi` to your composer.json dependency list (version 2.0.0 at the minimum for laravel 5 support)
+
+3. Run `composer update`.
 
 ### Requirements
 
@@ -152,8 +165,6 @@ class UsersHandler extends ApiHandler
 
     > **Note:** Extend your model from `EchoIt\JsonApi\Model` rather than `Eloquent` to get the proper response for linked resources.
 
-The features in the Handler class are each in their own functions, so you can easily override them with your own behavior if necessary. 
-	
 Current features
 -----
 
@@ -166,6 +177,9 @@ According to [jsonapi.org](http://jsonapi.org):
 * [Sorting](http://jsonapi.org/format/#fetching-sorting)
 * [Filtering](http://jsonapi.org/format/#fetching-filtering)
 * [Pagination] (http://jsonapi.org/format/#fetching-pagination)
+
+The features in the Handler class are each in their own function (eg. handlePaginationRequest, handleSortRequest, etc.), so you can easily override them with your own behaviour if desired. 
+	
 
 Wishlist
 -----

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "php": ">=5.4.0",
         "illuminate/database": "5.0.*",
         "illuminate/http": "5.0.*",
-        "illuminate/support": "5.0.*"
+        "illuminate/support": "5.0.*",
+		"illuminate/pagination" : "5.0.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*"

--- a/composer.json
+++ b/composer.json
@@ -9,9 +9,9 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/database": "4.2.*",
-        "illuminate/http": "4.2.*",
-        "illuminate/support": "4.2.*"
+        "illuminate/database": "5.0.*",
+        "illuminate/http": "5.0.*",
+        "illuminate/support": "5.0.*"
     },
     "require-dev": {
         "phpunit/phpunit": "4.*"

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,10 @@
         {
             "name": "Ronni Egeriis Persson",
             "email": "ronni@egeriis.me"
+        },
+		{
+            "name": "Jared Chapiewsky",
+            "email": "chapiewsky@earthlinginteractive.com"
         }
     ],
     "require": {

--- a/src/EchoIt/JsonApi/ErrorResponse.php
+++ b/src/EchoIt/JsonApi/ErrorResponse.php
@@ -20,7 +20,7 @@ class ErrorResponse extends JsonResponse
     {
         $data = [
             'errors' => [ array_merge(
-                [ 'code' => $errorCode, 'title' => $errorTitle ],
+                [ 'status' => $httpStatusCode, 'code' => $errorCode, 'title' => $errorTitle ],
                 $additionalAttrs
             ) ]
         ];

--- a/src/EchoIt/JsonApi/Handler.php
+++ b/src/EchoIt/JsonApi/Handler.php
@@ -61,7 +61,7 @@ abstract class Handler
      */
     public function fulfillRequest()
     {
-        if ( ! $this->supportsMethod($this->request->method)) {
+        if (! $this->supportsMethod($this->request->method)) {
             throw new Exception(
                 'Method not allowed',
                 static::ERROR_SCOPE | static::ERROR_HTTP_METHOD_NOT_ALLOWED,
@@ -82,7 +82,7 @@ abstract class Handler
         
         if ($models instanceof Response) {
             $response = $models;
-        }else if($models instanceof LengthAwarePaginator) {
+        } elseif ($models instanceof LengthAwarePaginator) {
             $items = new Collection($models->items());
             foreach ($items as $model) {
                 $model->load($this->exposedRelationsFromRequest());
@@ -93,8 +93,7 @@ abstract class Handler
             $response->links = $this->getPaginationLinks($models);
             $response->linked = $this->getLinkedModels($items);
             $response->errors = $this->getNonBreakingErrors();
-            
-        } else {            
+        } else {
             if ($models instanceof Collection) {
                 foreach ($models as $model) {
                     $model->load($this->exposedRelationsFromRequest());
@@ -148,16 +147,18 @@ abstract class Handler
             foreach ($this->exposedRelationsFromRequest() as $relationName) {
                 $value = static::getModelsForRelation($model, $relationName);
 
-                if (is_null($value)) continue;
+                if (is_null($value)) {
+                    continue;
+                }
 
                 foreach ($value as $obj) {
                     
                     // Check whether the object is already included in the response on it's ID
                     $duplicate = false;
                     $items = $links->where('id', $obj->getKey());
-                    if(count($items) > 0) {
-                        foreach($items as $item) {
-                            if($item->getTable() === $obj->getTable()) {
+                    if (count($items) > 0) {
+                        foreach ($items as $item) {
+                            if ($item->getTable() === $obj->getTable()) {
                                 $duplicate = true;
                                 break;
                             }
@@ -185,7 +186,8 @@ abstract class Handler
      * @param LengthAwarePaginator $paginator
      * @return array
      */
-    protected function getPaginationLinks($paginator) {
+    protected function getPaginationLinks($paginator)
+    {
         $links = [];
         
         $links['self'] = urldecode($paginator->url($paginator->currentPage()));
@@ -193,11 +195,11 @@ abstract class Handler
         $links['last'] = urldecode($paginator->url($paginator->lastPage()));
         
         $links['prev'] = urldecode($paginator->url($paginator->currentPage() - 1));
-        if($links['prev'] === $links['self'] || $links['prev'] === '') {
+        if ($links['prev'] === $links['self'] || $links['prev'] === '') {
             $links['prev'] = null;
         }
         $links['next'] = urldecode($paginator->nextPageUrl());
-        if($links['next'] === $links['self'] || $links['next'] === '') {
+        if ($links['next'] === $links['self'] || $links['next'] === '') {
             $links['next'] = null;
         }
         return $links;
@@ -268,7 +270,7 @@ abstract class Handler
      */
     protected static function getModelsForRelation($model, $relationKey)
     {
-        if(!method_exists ( $model, $relationKey )) {
+        if (!method_exists($model, $relationKey)) {
             throw new Exception(
                     'Relation "' . $relationKey . '" does not exist in model',
                     static::ERROR_SCOPE | static::ERROR_UNKNOWN_ID,
@@ -277,9 +279,13 @@ abstract class Handler
         }
         
         $relationModels = $model->{$relationKey};
-        if (is_null($relationModels)) return null;
+        if (is_null($relationModels)) {
+            return null;
+        }
 
-        if ( ! $relationModels instanceof Collection) return [ $relationModels ];
+        if (! $relationModels instanceof Collection) {
+            return [ $relationModels ];
+        }
         return $relationModels;
     }
 
@@ -293,7 +299,9 @@ abstract class Handler
      */
     protected static function getCollectionOrCreate(&$array, $key)
     {
-        if (array_key_exists($key, $array)) return $array[$key];
+        if (array_key_exists($key, $array)) {
+            return $array[$key];
+        }
         return ($array[$key] = new Collection);
     }
 
@@ -312,19 +320,19 @@ abstract class Handler
     }
     
     /**
-     * Function to handle sorting requests. 
-     * 
+     * Function to handle sorting requests.
+     *
      * @param  array $cols list of column names to sort on
      * @param  EchoIt\JsonApi\Model $model
      * @return EchoIt\JsonApi\Model
      */
     protected function handleSortRequest($cols, $model)
     {
-        foreach($cols as $col) {
+        foreach ($cols as $col) {
             $directionSymbol = substr($col, 0, 1);
             if ($directionSymbol === "+" || substr($col, 0, 3) === '%2B') {
                 $dir = 'asc';
-            } else if ($directionSymbol === "-") {
+            } elseif ($directionSymbol === "-") {
                 $dir = 'desc';
             } else {
                 throw new Exception(
@@ -341,15 +349,15 @@ abstract class Handler
     
     /**
      * Parses content from request into an array of values.
-     * 
+     *
      * @param  string $content
-     * @param  string $type the type the content is expected to be. 
+     * @param  string $type the type the content is expected to be.
      * @return array
      */
     protected function parseRequestContent($content, $type)
     {
         $content = json_decode($content, true);
-        if ( empty($content['data'])) {
+        if (empty($content['data'])) {
             throw new Exception(
                 'Payload either contains misformed JSON or missing "data" parameter.',
                 static::ERROR_SCOPE | static::ERROR_INVALID_ATTRS,
@@ -358,14 +366,14 @@ abstract class Handler
         }
         
         $data = $content['data'];
-        if ( !isset($data['type'])) {
+        if (!isset($data['type'])) {
             throw new Exception(
                 '"type" parameter not set in request.',
                 static::ERROR_SCOPE | static::ERROR_INVALID_ATTRS,
                 BaseResponse::HTTP_BAD_REQUEST
             );
         }
-        if ( $data['type'] !== $type) {
+        if ($data['type'] !== $type) {
             throw new Exception(
                 '"type" parameter is not valid. Expecting ' . $type,
                 static::ERROR_SCOPE | static::ERROR_INVALID_ATTRS,
@@ -378,17 +386,18 @@ abstract class Handler
     }
     
     /**
-     * Function to handle pagination requests. 
-     * 
+     * Function to handle pagination requests.
+     *
      * @param  EchoIt\JsonApi\Request $request
      * @param  EchoIt\JsonApi\Model $model
      * @param integer $total the total number of records
      * @return Illuminate\Pagination\LengthAwarePaginator
      */
-    protected function handlePaginationRequest($request, $model, $total = null) {
+    protected function handlePaginationRequest($request, $model, $total = null)
+    {
         $page = $request->pageNumber;
         $perPage = $request->pageSize;
-        if(!$total) {
+        if (!$total) {
             $total = $model->count();
         }
         $results = $model->forPage($page, $perPage)->get(array('*'));
@@ -396,37 +405,38 @@ abstract class Handler
             'path' => Paginator::resolveCurrentPath(),
             'pageName' => 'page[number]'
         ]);
-        $paginator->appends('page[size]' , $perPage);
-        if (!empty( $request->filter )) {
-            foreach($request->filter as $key=>$value) {
-                $paginator->appends($key , $value);
+        $paginator->appends('page[size]', $perPage);
+        if (!empty($request->filter)) {
+            foreach ($request->filter as $key=>$value) {
+                $paginator->appends($key, $value);
             }
         }
-        if (!empty( $request->sort )) {
-            $paginator->appends('sort' , implode(',', $request->sort));
-        } 
+        if (!empty($request->sort)) {
+            $paginator->appends('sort', implode(',', $request->sort));
+        }
         
         return $paginator;
     }
     
     /**
-     * Function to handle filtering requests. 
-     * 
+     * Function to handle filtering requests.
+     *
      * @param  array $filters key=>value pairs of column and value to filter on
      * @param  EchoIt\JsonApi\Model $model
      * @return EchoIt\JsonApi\Model
      */
-    protected function handleFilterRequest($filters, $model) {
-        foreach($filters as $key=>$value) {
+    protected function handleFilterRequest($filters, $model)
+    {
+        foreach ($filters as $key=>$value) {
             $model = $model->where($key, '=', $value);
         }
         return $model;
     }
     
     /**
-     * Default handling of GET request. 
+     * Default handling of GET request.
      * Must be called explicitly in handleGet function.
-     * 
+     *
      * @param  EchoIt\JsonApi\Request $request
      * @param  EchoIt\JsonApi\Model $model
      * @return EchoIt\JsonApi\Model|Illuminate\Pagination\LengthAwarePaginator
@@ -435,22 +445,22 @@ abstract class Handler
     {
         $total = null;
         if (empty($request->id)) {
-            if (!empty( $request->filter )) {
+            if (!empty($request->filter)) {
                 $model = $this->handleFilterRequest($request->filter, $model);
             }
-            if (!empty( $request->sort )) {
+            if (!empty($request->sort)) {
                 //if sorting AND paginating, get total count before sorting!
-                if($request->pageNumber) {
+                if ($request->pageNumber) {
                     $total = $model->count();
                 }
                 $model = $this->handleSortRequest($request->sort, $model);
-            } 
+            }
         } else {
             $model = $model->where('id', '=', $request->id);
         }
         
         try {
-            if($request->pageNumber && empty($request->id)) {
+            if ($request->pageNumber && empty($request->id)) {
                 $results = $this->handlePaginationRequest($request, $model, $total);
             } else {
                 $results = $model->get();
@@ -467,20 +477,19 @@ abstract class Handler
     }
     
     /**
-     * Default handling of POST request. 
+     * Default handling of POST request.
      * Must be called explicitly in handlePost function.
-     * 
+     *
      * @param  EchoIt\JsonApi\Request $request
      * @param  EchoIt\JsonApi\Model $model
      * @return EchoIt\JsonApi\Model
      */
     public function handlePostDefault(Request $request, $model)
     {
-
         $values = $this->parseRequestContent($request->content, $model->getTable());
         $model->fill($values);
 
-        if ( !$model->save()) {
+        if (!$model->save()) {
             throw new Exception(
                 'An unknown error occurred',
                 static::ERROR_SCOPE | static::ERROR_UNKNOWN,
@@ -492,9 +501,9 @@ abstract class Handler
     }
     
     /**
-     * Default handling of PUT request. 
+     * Default handling of PUT request.
      * Must be called explicitly in handlePut function.
-     * 
+     *
      * @param  EchoIt\JsonApi\Request $request
      * @param  EchoIt\JsonApi\Model $model
      * @return EchoIt\JsonApi\Model
@@ -512,11 +521,13 @@ abstract class Handler
         $updates = $this->parseRequestContent($request->content, $model->getTable());
         
         $model = $model::find($request->id);
-        if (is_null($model)) return null;
+        if (is_null($model)) {
+            return null;
+        }
 
         $model->fill($updates);
 
-        if ( !$model->save()) {
+        if (!$model->save()) {
             throw new Exception(
                 'An unknown error occurred',
                 static::ERROR_SCOPE | static::ERROR_UNKNOWN,
@@ -528,9 +539,9 @@ abstract class Handler
     }
     
     /**
-     * Default handling of DELETE request. 
+     * Default handling of DELETE request.
      * Must be called explicitly in handleDelete function.
-     * 
+     *
      * @param  EchoIt\JsonApi\Request $request
      * @param  EchoIt\JsonApi\Model $model
      * @return EchoIt\JsonApi\Model
@@ -546,11 +557,12 @@ abstract class Handler
         }
 
         $model = $model::find($request->id);
-        if (is_null($model)) return null;
+        if (is_null($model)) {
+            return null;
+        }
         
         $model->delete();
         
         return $model;
     }
-    
 }

--- a/src/EchoIt/JsonApi/Handler.php
+++ b/src/EchoIt/JsonApi/Handler.php
@@ -328,9 +328,9 @@ abstract class Handler
                 $dir = 'desc';
             } else {
                 throw new Exception(
-                    'Sort direction not specified but is required.',
+                    'Sort direction not specified but is required. Expecting "+" or "-".',
                     static::ERROR_SCOPE | static::ERROR_UNKNOWN_ID,
-                    BaseResponse::HTTP_INTERNAL_SERVER_ERROR
+                    BaseResponse::HTTP_BAD_REQUEST
                 );
             }
             $col = substr($col, 1);
@@ -353,7 +353,7 @@ abstract class Handler
             throw new Exception(
                 'Payload either contains misformed JSON or missing "data" parameter.',
                 static::ERROR_SCOPE | static::ERROR_INVALID_ATTRS,
-                BaseResponse::HTTP_INTERNAL_SERVER_ERROR
+                BaseResponse::HTTP_BAD_REQUEST
             );
         }
         
@@ -362,14 +362,14 @@ abstract class Handler
             throw new Exception(
                 '"type" parameter not set in request.',
                 static::ERROR_SCOPE | static::ERROR_INVALID_ATTRS,
-                BaseResponse::HTTP_INTERNAL_SERVER_ERROR
+                BaseResponse::HTTP_BAD_REQUEST
             );
         }
         if ( $data['type'] !== $type) {
             throw new Exception(
                 '"type" parameter is not valid. Expecting ' . $type,
                 static::ERROR_SCOPE | static::ERROR_INVALID_ATTRS,
-                BaseResponse::HTTP_INTERNAL_SERVER_ERROR
+                BaseResponse::HTTP_CONFLICT
             );
         }
         unset($data['type']);
@@ -457,7 +457,7 @@ abstract class Handler
             }
         } catch (\Illuminate\Database\QueryException $e) {
             throw new Exception(
-                'Database Request Failed in handleGetDefault',
+                'Database Request Failed',
                 static::ERROR_SCOPE | static::ERROR_UNKNOWN_ID,
                 BaseResponse::HTTP_INTERNAL_SERVER_ERROR,
                 array('details' => $e->getMessage())

--- a/src/EchoIt/JsonApi/Handler.php
+++ b/src/EchoIt/JsonApi/Handler.php
@@ -383,7 +383,7 @@ abstract class Handler
      * @param  EchoIt\JsonApi\Request $request
      * @param  EchoIt\JsonApi\Model $model
      * @param integer $total the total number of records
-     * @return LengthAwarePaginator
+     * @return Illuminate\Pagination\LengthAwarePaginator
      */
     protected function handlePaginationRequest($request, $model, $total = null) {
         $page = $request->pageNumber;
@@ -428,7 +428,7 @@ abstract class Handler
      * Must be called explicitly in handleGet function.
      * 
      * @param  EchoIt\JsonApi\Request $request
-     * @param  EchoIt\JsonApi\Model $models
+     * @param  EchoIt\JsonApi\Model $model
      * @return EchoIt\JsonApi\Model|Illuminate\Pagination\LengthAwarePaginator
      */
     protected function handleGetDefault(Request $request, $model)
@@ -471,7 +471,7 @@ abstract class Handler
      * Must be called explicitly in handlePost function.
      * 
      * @param  EchoIt\JsonApi\Request $request
-     * @param  EchoIt\JsonApi\Model $models
+     * @param  EchoIt\JsonApi\Model $model
      * @return EchoIt\JsonApi\Model
      */
     public function handlePostDefault(Request $request, $model)
@@ -496,7 +496,7 @@ abstract class Handler
      * Must be called explicitly in handlePut function.
      * 
      * @param  EchoIt\JsonApi\Request $request
-     * @param  EchoIt\JsonApi\Model $models
+     * @param  EchoIt\JsonApi\Model $model
      * @return EchoIt\JsonApi\Model
      */
     public function handlePutDefault(Request $request, $model)
@@ -532,7 +532,7 @@ abstract class Handler
      * Must be called explicitly in handleDelete function.
      * 
      * @param  EchoIt\JsonApi\Request $request
-     * @param  EchoIt\JsonApi\Model $models
+     * @param  EchoIt\JsonApi\Model $model
      * @return EchoIt\JsonApi\Model
      */
     public function handleDeleteDefault(Request $request, $model)

--- a/src/EchoIt/JsonApi/Handler.php
+++ b/src/EchoIt/JsonApi/Handler.php
@@ -151,6 +151,11 @@ abstract class Handler
                             continue;
                         }
                     }
+                    
+                    //add type property
+                    $attributes = $obj->getAttributes();
+                    $attributes['type'] = $obj->getTable();
+                    $obj->setRawAttributes($attributes);
 
                     $links->push($obj);
                 }

--- a/src/EchoIt/JsonApi/Handler.php
+++ b/src/EchoIt/JsonApi/Handler.php
@@ -138,7 +138,7 @@ abstract class Handler
 
                 foreach ($value as $obj) {
                     // Check whether the object is already included in the response on it's ID
-                    if (in_array($obj->getKey (), $links->lists($obj->primaryKey))) continue;
+                    if (in_array($obj->getKey(), $links->lists($obj->getKeyName()))) continue;
 
                     $links->push($obj);
                 }

--- a/src/EchoIt/JsonApi/Model.php
+++ b/src/EchoIt/JsonApi/Model.php
@@ -28,11 +28,13 @@ class Model extends \Eloquent
     {
         $relations = [];
         foreach ($this->getArrayableRelations() as $relation => $value) {
-            if (in_array($relation, $this->hidden)) continue;
+            if (in_array($relation, $this->hidden)) {
+                continue;
+            }
 
             if ($value instanceof BaseModel) {
                 $relations[$relation] = array('id' => $value->getKey(), 'type' => $value->getTable());
-            } else if ($value instanceof Collection) {
+            } elseif ($value instanceof Collection) {
                 $relation = \str_plural($relation);
                 $items = [];
                 foreach ($value as $item) {
@@ -46,7 +48,7 @@ class Model extends \Eloquent
         $attributes = $this->attributesToArray();
         $attributes['type'] = $this->getTable();
 
-        if ( ! count($relations)) {
+        if (! count($relations)) {
             return $attributes;
         }
 

--- a/src/EchoIt/JsonApi/Model.php
+++ b/src/EchoIt/JsonApi/Model.php
@@ -47,11 +47,11 @@ class Model extends \Eloquent
         $attributes['type'] = $this->getTable();
 
         if ( ! count($relations)) {
-            return $this->attributesToArray();
+            return $attributes;
         }
 
         return array_merge(
-            $this->attributesToArray(),
+            $attributes,
             [ 'links' => $relations ]
         );
     }

--- a/src/EchoIt/JsonApi/Model.php
+++ b/src/EchoIt/JsonApi/Model.php
@@ -31,12 +31,20 @@ class Model extends \Eloquent
             if (in_array($relation, $this->hidden)) continue;
 
             if ($value instanceof BaseModel) {
-                $relations[$relation] = $value->getKey ();
+                $relations[$relation] = array('id' => $value->getKey(), 'type' => $value->getTable());
             } else if ($value instanceof Collection) {
                 $relation = \str_plural($relation);
-                $relations[$relation] = array_pluck($value, current($value->modelKeys()));
+                $items = [];
+                foreach ($value as $item) {
+                    $items[] = array('id' => $item->getKey(), 'type' => $item->getTable());
+                }
+                $relations[$relation] = $items;
             }
         }
+        
+        //add type parameter
+        $attributes = $this->attributesToArray();
+        $attributes['type'] = $this->getTable();
 
         if ( ! count($relations)) {
             return $this->attributesToArray();

--- a/src/EchoIt/JsonApi/Request.php
+++ b/src/EchoIt/JsonApi/Request.php
@@ -9,7 +9,7 @@ class Request
 {
     
     /**
-     * Contains the URL of the request
+     * Contains the url of the request
      *
      * @var string
      */
@@ -56,6 +56,20 @@ class Request
      * @var array
      */
     public $filter;
+    
+    /**
+     * Specifies the page number to return results for
+     * @var integer
+     */
+    public $pageNumber;
+    
+    /**
+     * Specifies the number of results to return per page. Only used if 
+     * pagination is requested (ie. pageNumber is not null)
+     *
+     * @var integer
+     */
+    public $pageSize = 50;
 
     /**
      * Constructor.
@@ -67,8 +81,10 @@ class Request
      * @param array  $include
      * @param array  $sort
      * @param array  $filter
+     * @param integer $pageNumber
+     * @param integer $pageSize
      */
-    public function __construct($url, $method, $id = null, $content = null, $include = [], $sort = [], $filter = [])
+    public function __construct($url, $method, $id = null, $content = null, $include = [], $sort = [], $filter = [], $pageNumber = null, $pageSize = null)
     {
         $this->url = $url;
         $this->method = $method;
@@ -77,5 +93,10 @@ class Request
         $this->include = $include ?: [];
         $this->sort = $sort ?: [];
         $this->filter = $filter ?: [];
+        
+        $this->pageNumber = $pageNumber ?: null;
+        if ($pageSize) {
+            $this->pageSize = $pageSize;
+        }
     }
 }

--- a/src/EchoIt/JsonApi/Request.php
+++ b/src/EchoIt/JsonApi/Request.php
@@ -48,6 +48,8 @@ class Request
      * @param string $method
      * @param int    $id
      * @param array  $include
+     * @param array  $sort
+     * @param array  $filter
      */
     public function __construct($method, $id = null, $include = [], $sort = [], $filter = [])
     {

--- a/src/EchoIt/JsonApi/Request.php
+++ b/src/EchoIt/JsonApi/Request.php
@@ -64,7 +64,7 @@ class Request
     public $pageNumber;
     
     /**
-     * Specifies the number of results to return per page. Only used if 
+     * Specifies the number of results to return per page. Only used if
      * pagination is requested (ie. pageNumber is not null)
      *
      * @var integer
@@ -73,7 +73,7 @@ class Request
 
     /**
      * Constructor.
-     * 
+     *
      * @param string $url
      * @param string $method
      * @param int    $id

--- a/src/EchoIt/JsonApi/Request.php
+++ b/src/EchoIt/JsonApi/Request.php
@@ -27,6 +27,20 @@ class Request
      * @var array
      */
     public $include;
+	
+	/**
+     * Contains an array of column names to sort on
+     *
+     * @var array
+     */
+    public $sort;
+	
+	/**
+     * Contains an array of key/value pairs to filter on
+     *
+     * @var array
+     */
+    public $filter;
 
     /**
      * Constructor.
@@ -35,10 +49,12 @@ class Request
      * @param int    $id
      * @param array  $include
      */
-    public function __construct($method, $id = null, $include = [])
+    public function __construct($method, $id = null, $include = [], $sort = [], $filter = [])
     {
         $this->method = $method;
         $this->id = $id;
         $this->include = $include ?: [];
+		$this->sort = $sort ?: [];
+		$this->filter = $filter ?: [];
     }
 }

--- a/src/EchoIt/JsonApi/Request.php
+++ b/src/EchoIt/JsonApi/Request.php
@@ -7,6 +7,14 @@
  */
 class Request
 {
+    
+    /**
+     * Contains the URL of the request
+     *
+     * @var string
+     */
+    public $url;
+    
     /**
      * Contains the HTTP method of the request
      *
@@ -20,22 +28,29 @@ class Request
      * @var int
      */
     public $id;
-
+    
+    /**
+     * Contains any content in request
+     *
+     * @var string
+     */
+    public $content;
+    
     /**
      * Contains an array of linked resource collections to load
      *
      * @var array
      */
     public $include;
-	
-	/**
+    
+    /**
      * Contains an array of column names to sort on
      *
      * @var array
      */
     public $sort;
-	
-	/**
+    
+    /**
      * Contains an array of key/value pairs to filter on
      *
      * @var array
@@ -44,19 +59,23 @@ class Request
 
     /**
      * Constructor.
-     *
+     * 
+     * @param string $url
      * @param string $method
      * @param int    $id
+     * @param mixed $content
      * @param array  $include
      * @param array  $sort
      * @param array  $filter
      */
-    public function __construct($method, $id = null, $include = [], $sort = [], $filter = [])
+    public function __construct($url, $method, $id = null, $content = null, $include = [], $sort = [], $filter = [])
     {
+        $this->url = $url;
         $this->method = $method;
         $this->id = $id;
+        $this->content = $content;
         $this->include = $include ?: [];
-		$this->sort = $sort ?: [];
-		$this->filter = $filter ?: [];
+        $this->sort = $sort ?: [];
+        $this->filter = $filter ?: [];
     }
 }

--- a/src/EchoIt/JsonApi/Response.php
+++ b/src/EchoIt/JsonApi/Response.php
@@ -65,6 +65,6 @@ class Response
         return new JsonResponse(array_merge(
             [ $bodyKey => $this->body ],
             array_filter($this->responseData)
-        ), $this->httpStatusCode, [], $options);
+        ), $this->httpStatusCode, ['Content-Type' => 'application/vnd.api+json'], $options);
     }
 }

--- a/tests/ErrorResponseTest.php
+++ b/tests/ErrorResponseTest.php
@@ -4,19 +4,22 @@ use EchoIt\JsonApi\ErrorResponse;
 
 class ErrorResponseTest extends PHPUnit_Framework_TestCase
 {
-    public function testResponseHeaders() {
+    public function testResponseHeaders()
+    {
         $res = new ErrorResponse(404, 100, 'An error occurred');
 
         $this->assertEquals(404, $res->getStatusCode());
         $this->assertEquals('application/json', $res->headers->get('Content-Type'));
     }
 
-    public function testResponseBody() {
+    public function testResponseBody()
+    {
         $res = new ErrorResponse(404, 100, 'An error occurred');
         $this->assertEquals('{"errors":[{"status":404,"code":100,"title":"An error occurred"}]}', $res->getContent());
     }
 
-    public function testResponseWithAdditionalAttrs() {
+    public function testResponseWithAdditionalAttrs()
+    {
         $res = new ErrorResponse(404, 100, 'An error occurred', [
             'stacktrace' => [
                 'line' => 100,

--- a/tests/ErrorResponseTest.php
+++ b/tests/ErrorResponseTest.php
@@ -13,7 +13,7 @@ class ErrorResponseTest extends PHPUnit_Framework_TestCase
 
     public function testResponseBody() {
         $res = new ErrorResponse(404, 100, 'An error occurred');
-        $this->assertEquals('{"errors":[{"code":100,"title":"An error occurred"}]}', $res->getContent());
+        $this->assertEquals('{"errors":[{"status":404,"code":100,"title":"An error occurred"}]}', $res->getContent());
     }
 
     public function testResponseWithAdditionalAttrs() {
@@ -23,6 +23,6 @@ class ErrorResponseTest extends PHPUnit_Framework_TestCase
                 'file' => 'script.php'
             ]
         ]);
-        $this->assertEquals('{"errors":[{"code":100,"title":"An error occurred","stacktrace":{"line":100,"file":"script.php"}}]}', $res->getContent());
+        $this->assertEquals('{"errors":[{"status":404,"code":100,"title":"An error occurred","stacktrace":{"line":100,"file":"script.php"}}]}', $res->getContent());
     }
 }

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -16,7 +16,7 @@ class HandlerTest extends PHPUnit_Framework_TestCase
 {
     public function testMockInstanceWithNoGETSupport()
     {
-        $req = new Request('GET');
+        $req = new Request('http://www.example.com/', 'GET');
         $stub = $this->getMockForAbstractClass('EchoIt\JsonApi\Handler', [$req]);
 
         $this->setExpectedException('EchoIt\JsonApi\Exception');
@@ -25,7 +25,7 @@ class HandlerTest extends PHPUnit_Framework_TestCase
 
     public function testHandler()
     {
-        $req = new Request('GET');
+        $req = new Request('http://www.example.com/', 'GET');
         $handler = new HandlerWithGETSupport($req);
         $handlerResult = $handler->fulfillRequest();
 
@@ -34,7 +34,7 @@ class HandlerTest extends PHPUnit_Framework_TestCase
 
     public function testHandlerUnsupportedRequest()
     {
-        $req = new Request('PUT');
+        $req = new Request('http://www.example.com/', 'PUT', null);
         $handler = new HandlerWithGETSupport($req);
 
         $this->setExpectedException('EchoIt\JsonApi\Exception');


### PR DESCRIPTION
For my own project's needs, I updated your library to work with Laravel 5, updated to the jsonapi 1.0.0.rc2 specs, and added some basic support for sorting, filtering, and pagination. I wanted to offer my changes as a pull request. I have continued semantic versioning, so you can maintain Laravel 4 support in version 1.X.X. 

If you are not interested, no problem. I think I'm going to branch this off into into it's own repo and continue adding features and updating with the spec as it approaches 1.0. I wanted to thank you for providing a great base to build on, and I will continue to give you attribution in the code and in the readme.md.
