### PR TITLE
Correctly return model on PUT request if changed

### DIFF
--- a/src/EchoIt/JsonApi/Handler.php
+++ b/src/EchoIt/JsonApi/Handler.php
@@ -108,11 +108,9 @@ abstract class Handler
             // if we did a put request, we need to ensure that the model wasn't
             // changed in other ways than those specified by the request
             //     Ref: http://jsonapi.org/format/#crud-updating-responses-200
-            if ($this->request->method === 'PUT')
-            {
+            if ($this->request->method === 'PUT') {
                 // check if the model has been changed
-                if ($models->isChanged())
-                {
+                if ($models->isChanged()) {
                     // return our response as if there was a GET request
                     $statusCode = static::successfulHttpStatusCode('GET');
                 }
@@ -561,10 +559,8 @@ abstract class Handler
 
         // loop through the new attributes, and ensure they are identical
         // to the original ones. if not, then we need to return the model
-        foreach ($newAttributes as $attribute => $value)
-        {
-            if (! array_key_exists($attribute, $originalAttributes) || $value !== $originalAttributes[$attribute])
-            {
+        foreach ($newAttributes as $attribute => $value) {
+            if (! array_key_exists($attribute, $originalAttributes) || $value !== $originalAttributes[$attribute]) {
                 $model->markChanged();
                 break;
             }

--- a/src/EchoIt/JsonApi/Handler.php
+++ b/src/EchoIt/JsonApi/Handler.php
@@ -79,7 +79,7 @@ abstract class Handler
                 BaseResponse::HTTP_NOT_FOUND
             );
         }
-        
+
         if ($models instanceof Response) {
             $response = $models;
         } elseif ($models instanceof LengthAwarePaginator) {
@@ -87,9 +87,9 @@ abstract class Handler
             foreach ($items as $model) {
                 $model->load($this->exposedRelationsFromRequest());
             }
-            
+
             $response = new Response($items, static::successfulHttpStatusCode($this->request->method));
-            
+
             $response->links = $this->getPaginationLinks($models);
             $response->linked = $this->getLinkedModels($items);
             $response->errors = $this->getNonBreakingErrors();
@@ -101,9 +101,9 @@ abstract class Handler
             } else {
                 $models->load($this->exposedRelationsFromRequest());
             }
-            
+
             $response = new Response($models, static::successfulHttpStatusCode($this->request->method));
-        
+
             $response->linked = $this->getLinkedModels($models);
             $response->errors = $this->getNonBreakingErrors();
         }
@@ -152,7 +152,7 @@ abstract class Handler
                 }
 
                 foreach ($value as $obj) {
-                    
+
                     // Check whether the object is already included in the response on it's ID
                     $duplicate = false;
                     $items = $links->where('id', $obj->getKey());
@@ -167,7 +167,7 @@ abstract class Handler
                             continue;
                         }
                     }
-                    
+
                     //add type property
                     $attributes = $obj->getAttributes();
                     $attributes['type'] = $obj->getTable();
@@ -180,7 +180,7 @@ abstract class Handler
 
         return $links->toArray();
     }
-    
+
     /**
      * Return pagination links as array
      * @param LengthAwarePaginator $paginator
@@ -189,11 +189,11 @@ abstract class Handler
     protected function getPaginationLinks($paginator)
     {
         $links = [];
-        
+
         $links['self'] = urldecode($paginator->url($paginator->currentPage()));
         $links['first'] = urldecode($paginator->url(1));
         $links['last'] = urldecode($paginator->url($paginator->lastPage()));
-        
+
         $links['prev'] = urldecode($paginator->url($paginator->currentPage() - 1));
         if ($links['prev'] === $links['self'] || $links['prev'] === '') {
             $links['prev'] = null;
@@ -235,7 +235,7 @@ abstract class Handler
     public static function successfulHttpStatusCode($method)
     {
         switch ($method) {
-            
+
             case 'POST':
                 return BaseResponse::HTTP_CREATED;
             case 'PUT':
@@ -277,7 +277,7 @@ abstract class Handler
                     BaseResponse::HTTP_INTERNAL_SERVER_ERROR
                 );
         }
-        
+
         $relationModels = $model->{$relationKey};
         if (is_null($relationModels)) {
             return null;
@@ -318,7 +318,7 @@ abstract class Handler
     {
         return \str_plural($relationName);
     }
-    
+
     /**
      * Function to handle sorting requests.
      *
@@ -346,7 +346,7 @@ abstract class Handler
         }
         return $model;
     }
-    
+
     /**
      * Parses content from request into an array of values.
      *
@@ -364,7 +364,7 @@ abstract class Handler
                 BaseResponse::HTTP_BAD_REQUEST
             );
         }
-        
+
         $data = $content['data'];
         if (!isset($data['type'])) {
             throw new Exception(
@@ -381,10 +381,10 @@ abstract class Handler
             );
         }
         unset($data['type']);
-        
+
         return $data;
     }
-    
+
     /**
      * Function to handle pagination requests.
      *
@@ -414,10 +414,10 @@ abstract class Handler
         if (!empty($request->sort)) {
             $paginator->appends('sort', implode(',', $request->sort));
         }
-        
+
         return $paginator;
     }
-    
+
     /**
      * Function to handle filtering requests.
      *
@@ -432,7 +432,7 @@ abstract class Handler
         }
         return $model;
     }
-    
+
     /**
      * Default handling of GET request.
      * Must be called explicitly in handleGet function.
@@ -458,7 +458,7 @@ abstract class Handler
         } else {
             $model = $model->where('id', '=', $request->id);
         }
-        
+
         try {
             if ($request->pageNumber && empty($request->id)) {
                 $results = $this->handlePaginationRequest($request, $model, $total);
@@ -475,7 +475,7 @@ abstract class Handler
         }
         return $results;
     }
-    
+
     /**
      * Default handling of POST request.
      * Must be called explicitly in handlePost function.
@@ -496,10 +496,10 @@ abstract class Handler
                 BaseResponse::HTTP_INTERNAL_SERVER_ERROR
             );
         }
-        
+
         return $model;
     }
-    
+
     /**
      * Default handling of PUT request.
      * Must be called explicitly in handlePut function.
@@ -519,7 +519,7 @@ abstract class Handler
         }
 
         $updates = $this->parseRequestContent($request->content, $model->getTable());
-        
+
         $model = $model::find($request->id);
         if (is_null($model)) {
             return null;
@@ -534,10 +534,10 @@ abstract class Handler
                 BaseResponse::HTTP_INTERNAL_SERVER_ERROR
             );
         }
-        
+
         return $model;
     }
-    
+
     /**
      * Default handling of DELETE request.
      * Must be called explicitly in handleDelete function.
@@ -560,9 +560,9 @@ abstract class Handler
         if (is_null($model)) {
             return null;
         }
-        
+
         $model->delete();
-        
+
         return $model;
     }
 }

--- a/src/EchoIt/JsonApi/Model.php
+++ b/src/EchoIt/JsonApi/Model.php
@@ -19,6 +19,36 @@ class Model extends \Eloquent
     protected $guarded = ['id', 'created_at', 'updated_at'];
 
     /**
+     * Has this model been changed inother ways than those
+     * specified by the request
+     *
+     * Ref: http://jsonapi.org/format/#crud-updating-responses-200
+     *
+     * @var  boolean
+     */
+    protected $changed = false;
+
+    /**
+     * mark this model as changed
+     *
+     * @return  void
+     */
+    public function markChanged($changed = true)
+    {
+        $this->changed = (bool) $changed;
+    }
+
+    /**
+     * has this model been changed
+     *
+     * @return  void
+     */
+    public function isChanged()
+    {
+        return $this->changed;
+    }
+
+    /**
      * Convert the model instance to an array. This method overrides that of
      * Eloquent to prevent relations to be serialize into output array.
      *

--- a/src/EchoIt/JsonApi/Request.php
+++ b/src/EchoIt/JsonApi/Request.php
@@ -7,14 +7,14 @@
  */
 class Request
 {
-    
+
     /**
      * Contains the url of the request
      *
      * @var string
      */
     public $url;
-    
+
     /**
      * Contains the HTTP method of the request
      *
@@ -28,41 +28,41 @@ class Request
      * @var int
      */
     public $id;
-    
+
     /**
      * Contains any content in request
      *
      * @var string
      */
     public $content;
-    
+
     /**
      * Contains an array of linked resource collections to load
      *
      * @var array
      */
     public $include;
-    
+
     /**
      * Contains an array of column names to sort on
      *
      * @var array
      */
     public $sort;
-    
+
     /**
      * Contains an array of key/value pairs to filter on
      *
      * @var array
      */
     public $filter;
-    
+
     /**
      * Specifies the page number to return results for
      * @var integer
      */
     public $pageNumber;
-    
+
     /**
      * Specifies the number of results to return per page. Only used if
      * pagination is requested (ie. pageNumber is not null)
@@ -93,7 +93,7 @@ class Request
         $this->include = $include ?: [];
         $this->sort = $sort ?: [];
         $this->filter = $filter ?: [];
-        
+
         $this->pageNumber = $pageNumber ?: null;
         if ($pageSize) {
             $this->pageSize = $pageSize;


### PR DESCRIPTION
If the model we are executing a PUT request on was changed in other ways than those specified by the request, then we need to return a 200 OK response.

Ref: http://jsonapi.org/format/#crud-updating-responses-200
