### PR TITLE
Allow a custom resource type to be set for a model

### DIFF
--- a/src/EchoIt/JsonApi/Handler.php
+++ b/src/EchoIt/JsonApi/Handler.php
@@ -79,7 +79,7 @@ abstract class Handler
                 BaseResponse::HTTP_NOT_FOUND
             );
         }
-        
+
         if ($models instanceof Response) {
             $response = $models;
         } elseif ($models instanceof LengthAwarePaginator) {
@@ -87,9 +87,9 @@ abstract class Handler
             foreach ($items as $model) {
                 $model->load($this->exposedRelationsFromRequest());
             }
-            
+
             $response = new Response($items, static::successfulHttpStatusCode($this->request->method));
-            
+
             $response->links = $this->getPaginationLinks($models);
             $response->linked = $this->getLinkedModels($items);
             $response->errors = $this->getNonBreakingErrors();
@@ -101,9 +101,9 @@ abstract class Handler
             } else {
                 $models->load($this->exposedRelationsFromRequest());
             }
-            
+
             $response = new Response($models, static::successfulHttpStatusCode($this->request->method));
-        
+
             $response->linked = $this->getLinkedModels($models);
             $response->errors = $this->getNonBreakingErrors();
         }
@@ -152,13 +152,13 @@ abstract class Handler
                 }
 
                 foreach ($value as $obj) {
-                    
+
                     // Check whether the object is already included in the response on it's ID
                     $duplicate = false;
                     $items = $links->where('id', $obj->getKey());
                     if (count($items) > 0) {
                         foreach ($items as $item) {
-                            if ($item->getTable() === $obj->getTable()) {
+                            if ($item->getResourceType() === $obj->getResourceType()) {
                                 $duplicate = true;
                                 break;
                             }
@@ -167,10 +167,10 @@ abstract class Handler
                             continue;
                         }
                     }
-                    
+
                     //add type property
                     $attributes = $obj->getAttributes();
-                    $attributes['type'] = $obj->getTable();
+                    $attributes['type'] = $obj->getResourceType();
                     $obj->setRawAttributes($attributes);
 
                     $links->push($obj);
@@ -180,7 +180,7 @@ abstract class Handler
 
         return $links->toArray();
     }
-    
+
     /**
      * Return pagination links as array
      * @param LengthAwarePaginator $paginator
@@ -189,11 +189,11 @@ abstract class Handler
     protected function getPaginationLinks($paginator)
     {
         $links = [];
-        
+
         $links['self'] = urldecode($paginator->url($paginator->currentPage()));
         $links['first'] = urldecode($paginator->url(1));
         $links['last'] = urldecode($paginator->url($paginator->lastPage()));
-        
+
         $links['prev'] = urldecode($paginator->url($paginator->currentPage() - 1));
         if ($links['prev'] === $links['self'] || $links['prev'] === '') {
             $links['prev'] = null;
@@ -235,7 +235,7 @@ abstract class Handler
     public static function successfulHttpStatusCode($method)
     {
         switch ($method) {
-            
+
             case 'POST':
                 return BaseResponse::HTTP_CREATED;
             case 'PUT':
@@ -277,7 +277,7 @@ abstract class Handler
                     BaseResponse::HTTP_INTERNAL_SERVER_ERROR
                 );
         }
-        
+
         $relationModels = $model->{$relationKey};
         if (is_null($relationModels)) {
             return null;
@@ -318,7 +318,7 @@ abstract class Handler
     {
         return \str_plural($relationName);
     }
-    
+
     /**
      * Function to handle sorting requests.
      *
@@ -346,7 +346,7 @@ abstract class Handler
         }
         return $model;
     }
-    
+
     /**
      * Parses content from request into an array of values.
      *
@@ -364,7 +364,7 @@ abstract class Handler
                 BaseResponse::HTTP_BAD_REQUEST
             );
         }
-        
+
         $data = $content['data'];
         if (!isset($data['type'])) {
             throw new Exception(
@@ -381,10 +381,10 @@ abstract class Handler
             );
         }
         unset($data['type']);
-        
+
         return $data;
     }
-    
+
     /**
      * Function to handle pagination requests.
      *
@@ -414,10 +414,10 @@ abstract class Handler
         if (!empty($request->sort)) {
             $paginator->appends('sort', implode(',', $request->sort));
         }
-        
+
         return $paginator;
     }
-    
+
     /**
      * Function to handle filtering requests.
      *
@@ -432,7 +432,7 @@ abstract class Handler
         }
         return $model;
     }
-    
+
     /**
      * Default handling of GET request.
      * Must be called explicitly in handleGet function.
@@ -458,7 +458,7 @@ abstract class Handler
         } else {
             $model = $model->where('id', '=', $request->id);
         }
-        
+
         try {
             if ($request->pageNumber && empty($request->id)) {
                 $results = $this->handlePaginationRequest($request, $model, $total);
@@ -475,7 +475,7 @@ abstract class Handler
         }
         return $results;
     }
-    
+
     /**
      * Default handling of POST request.
      * Must be called explicitly in handlePost function.
@@ -486,7 +486,7 @@ abstract class Handler
      */
     public function handlePostDefault(Request $request, $model)
     {
-        $values = $this->parseRequestContent($request->content, $model->getTable());
+        $values = $this->parseRequestContent($request->content, $model->getResourceType());
         $model->fill($values);
 
         if (!$model->save()) {
@@ -496,10 +496,10 @@ abstract class Handler
                 BaseResponse::HTTP_INTERNAL_SERVER_ERROR
             );
         }
-        
+
         return $model;
     }
-    
+
     /**
      * Default handling of PUT request.
      * Must be called explicitly in handlePut function.
@@ -518,8 +518,8 @@ abstract class Handler
             );
         }
 
-        $updates = $this->parseRequestContent($request->content, $model->getTable());
-        
+        $updates = $this->parseRequestContent($request->content, $model->getResourceType());
+
         $model = $model::find($request->id);
         if (is_null($model)) {
             return null;
@@ -534,10 +534,10 @@ abstract class Handler
                 BaseResponse::HTTP_INTERNAL_SERVER_ERROR
             );
         }
-        
+
         return $model;
     }
-    
+
     /**
      * Default handling of DELETE request.
      * Must be called explicitly in handleDelete function.
@@ -560,9 +560,9 @@ abstract class Handler
         if (is_null($model)) {
             return null;
         }
-        
+
         $model->delete();
-        
+
         return $model;
     }
 }

--- a/src/EchoIt/JsonApi/Model.php
+++ b/src/EchoIt/JsonApi/Model.php
@@ -19,6 +19,25 @@ class Model extends \Eloquent
     protected $guarded = ['id', 'created_at', 'updated_at'];
 
     /**
+     * The resource type. If null, when the model is rendered,
+     * the table name will be used
+     *
+     * @var  null|string
+     */
+    protected $resourceType = null;
+
+    /**
+     * Get the resource type of the model
+     *
+     * @return  string
+     */
+    public function getResourceType()
+    {
+        // return the resource type if it is not null; table otherwize
+        return ($this->resourceType ?: $this->getTable());
+    }
+
+    /**
      * Convert the model instance to an array. This method overrides that of
      * Eloquent to prevent relations to be serialize into output array.
      *
@@ -33,12 +52,12 @@ class Model extends \Eloquent
             }
 
             if ($value instanceof BaseModel) {
-                $relations[$relation] = array('id' => $value->getKey(), 'type' => $value->getTable());
+                $relations[$relation] = array('id' => $value->getKey(), 'type' => $value->getResourceType());
             } elseif ($value instanceof Collection) {
                 $relation = \str_plural($relation);
                 $items = [];
                 foreach ($value as $item) {
-                    $items[] = array('id' => $item->getKey(), 'type' => $item->getTable());
+                    $items[] = array('id' => $item->getKey(), 'type' => $item->getResourceType());
                 }
                 $relations[$relation] = $items;
             }
@@ -46,7 +65,7 @@ class Model extends \Eloquent
 
         //add type parameter
         $attributes = $this->attributesToArray();
-        $attributes['type'] = $this->getTable();
+        $attributes['type'] = $this->getResourceType();
 
         if (! count($relations)) {
             return $attributes;


### PR DESCRIPTION
This is necessary when you have a models in multiple namespaces,
when you have a model referencing the same table name as another (but a different db connection).
