### PR TITLE
getTable call replaced with getResourceType

### DIFF
--- a/src/EchoIt/JsonApi/Handler.php
+++ b/src/EchoIt/JsonApi/Handler.php
@@ -529,7 +529,7 @@ abstract class Handler
             );
         }
 
-        $updates = $this->parseRequestContent($request->content, $model->getTable());
+        $updates = $this->parseRequestContent($request->content, $model->getResourceType());
 
         $model = $model::find($request->id);
         if (is_null($model)) {


### PR DESCRIPTION
Switch to using call to getResourceType to enable override of the resource type within the model
