### PR TITLE
Fix pivot linkage

### DIFF
--- a/src/EchoIt/JsonApi/Model.php
+++ b/src/EchoIt/JsonApi/Model.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model as BaseModel;
+use Illuminate\Database\Eloquent\Relations\Pivot as Pivot;
 
 /**
  * This class is used to extend models from, that will be exposed through
@@ -78,6 +79,10 @@ class Model extends \Eloquent
         $relations = [];
         foreach ($this->getArrayableRelations() as $relation => $value) {
             if (in_array($relation, $this->hidden)) {
+                continue;
+            }
+
+            if ($value instanceof Pivot) {
                 continue;
             }
 


### PR DESCRIPTION
This fixes an issue I'm having when attempting to include a manyToMany relationship

From investigations it looks like the toArray overload is attempting to further load the pivot resource and this call getResourceType() on it. This results in an exception

If i've misunderstood whats happening here and there is a better fix please feel free to disregard the PR!
