### PR TITLE
Ability to automatically expose relations for a resource

### DIFF
--- a/src/EchoIt/JsonApi/Model.php
+++ b/src/EchoIt/JsonApi/Model.php
@@ -37,6 +37,14 @@ class Model extends \Eloquent
     protected $resourceType = null;
 
     /**
+     * Expose the resource relations links by default when viewing a
+     * resource
+     *
+     * @var  array
+     */
+    protected $exposedRelations = [];
+
+    /**
      * mark this model as changed
      *
      * @return  void
@@ -76,6 +84,12 @@ class Model extends \Eloquent
     public function toArray()
     {
         $relations = [];
+
+        // include any relations exposed by default
+       foreach ($this->exposedRelations as $relation) {
+            $this->load($relation);
+        }
+
         foreach ($this->getArrayableRelations() as $relation => $value) {
             if (in_array($relation, $this->hidden)) {
                 continue;


### PR DESCRIPTION
As per specification a resource may choose to expose relations within a
links node (this happens currently when including a relation)

This PR adds an attribute to the model which enables a resource to
identify relations it wishes to expose via the links permanently (when
no include is specified).

This identifies the resource within the links node but DOES NOT include
the relation.

http://jsonapi.org/format/#document-structure-resource-relationships
