### PR TITLE
Adds validation error handling

### DIFF
--- a/src/EchoIt/JsonApi/Exception/Validation.php
+++ b/src/EchoIt/JsonApi/Exception/Validation.php
@@ -1,0 +1,42 @@
+<?php namespace EchoIt\JsonApi\Exception;
+
+use EchoIt\JsonApi\Exception;
+use EchoIt\JsonApi\MultiErrorResponse;
+use Illuminate\Support\MessageBag as ValidationMessages;
+
+/**
+ * Validation represents an Exception that can be thrown in the event of a validation failure where a JSON response may be expected.
+ *
+ * @author Matt <matt@ninjapenguin.co.uk>
+ */
+class Validation extends Exception
+{
+    protected $httpStatusCode;
+    protected $validationMessages;
+
+    /**
+     * Constructor.
+     *
+     * @param string                        $message        The Exception message to throw
+     * @param int                           $code           The Exception code
+     * @param int                           $httpStatusCode HTTP status code which can be used for broken request
+     * @param Illuminate\Support\MessageBag $errors         Validation errors
+     */
+    public function __construct($message = '', $code = 0, $httpStatusCode = 500, ValidationMessages $messages = NULL)
+    {
+        parent::__construct($message, $code);
+
+        $this->httpStatusCode = $httpStatusCode;
+        $this->validationMessages = $messages;
+    }
+
+    /**
+     * This method returns a HTTP response representation of the Exception
+     *
+     * @return JsonApi\ErrorResponse
+     */
+    public function response()
+    {
+        return new MultiErrorResponse($this->httpStatusCode, $this->code, $this->message, $this->validationMessages);
+    }
+}

--- a/src/EchoIt/JsonApi/Exception/Validation.php
+++ b/src/EchoIt/JsonApi/Exception/Validation.php
@@ -20,7 +20,7 @@ class Validation extends Exception
      * @param string                        $message        The Exception message to throw
      * @param int                           $code           The Exception code
      * @param int                           $httpStatusCode HTTP status code which can be used for broken request
-     * @param Illuminate\Support\MessageBag $errors         Validation errors
+     * @param Illuminate\Support\MessageBag $messages       Validation errors
      */
     public function __construct($message = '', $code = 0, $httpStatusCode = 500, ValidationMessages $messages = NULL)
     {
@@ -33,7 +33,7 @@ class Validation extends Exception
     /**
      * This method returns a HTTP response representation of the Exception
      *
-     * @return JsonApi\ErrorResponse
+     * @return JsonApi\MultiErrorResponse
      */
     public function response()
     {

--- a/src/EchoIt/JsonApi/Model.php
+++ b/src/EchoIt/JsonApi/Model.php
@@ -127,7 +127,7 @@ class Model extends \Eloquent
      *
      * @param  Array  $values  user passed values (request data)
      *
-     * @return true|Illuminate\Support\MessageBag  True on pass, MessageBag of errors on fail
+     * @return bool|Illuminate\Support\MessageBag  True on pass, MessageBag of errors on fail
      */
     public function validateArray(Array $values)
     {

--- a/src/EchoIt/JsonApi/Model.php
+++ b/src/EchoIt/JsonApi/Model.php
@@ -1,5 +1,6 @@
 <?php namespace EchoIt\JsonApi;
 
+use Validator;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model as BaseModel;
 use Illuminate\Database\Eloquent\Relations\Pivot as Pivot;
@@ -119,6 +120,37 @@ class Model extends \Eloquent
     {
         // return the resource type if it is not null; table otherwize
         return ($this->resourceType ?: $this->getTable());
+    }
+
+    /**
+     * Validate passed values
+     *
+     * @param  Array  $values  user passed values (request data)
+     *
+     * @return true|Illuminate\Support\MessageBag  True on pass, MessageBag of errors on fail
+     */
+    public function validateArray(Array $values)
+    {
+        if (count($this->getValidationRules())) {
+            $validator = Validator::make($values, $this->getValidationRules());
+
+            if ($validator->fails()) {
+                return $validator->errors();
+            }
+        }
+
+        return True;
+    }
+
+    /**
+     * Return model validation rules
+     * Models should overload this to provide their validation rules
+     *
+     * @return Array validation rules
+     */
+    public function getValidationRules()
+    {
+        return [];
     }
 
     /**

--- a/src/EchoIt/JsonApi/MultiErrorResponse.php
+++ b/src/EchoIt/JsonApi/MultiErrorResponse.php
@@ -1,0 +1,37 @@
+<?php namespace EchoIt\JsonApi;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\MessageBag as ValidationMessages;
+
+/**
+ * MultiErrorResponse represents a HTTP error response containing multiple errors with a JSON API compliant payload.
+ *
+ * @author Matt <matt@ninjapenguin.co.uk>
+ */
+class MultiErrorResponse extends JsonResponse
+{
+    /**
+     * Constructor.
+     *
+     * @param int                           $httpStatusCode   HTTP status code
+     * @param mixed                         $errorCode        Internal error code
+     * @param string                        $errorTitle       Error description
+     * @param Illuminate\Support\MessageBag $errors           Validation errors
+     */
+    public function __construct($httpStatusCode, $errorCode, $errorTitle, ValidationMessages $errors = NULL)
+    {
+        $data = [ 'errors' => [] ];
+
+        foreach ($errors->keys() as $field) {
+
+            foreach ($errors->get($field) as $message) {
+
+                $data['errors'][] = [ 'status' => $httpStatusCode, 'code' => $errorCode, 'title' =>  'Validation Fail', 'detail' => $message, 'meta' => ['field' => $field] ];
+
+            }
+
+        }
+
+        parent::__construct($data, $httpStatusCode);
+    }
+}

--- a/src/EchoIt/JsonApi/MultiErrorResponse.php
+++ b/src/EchoIt/JsonApi/MultiErrorResponse.php
@@ -22,14 +22,16 @@ class MultiErrorResponse extends JsonResponse
     {
         $data = [ 'errors' => [] ];
 
-        foreach ($errors->keys() as $field) {
+        if ($errors) {
+            foreach ($errors->keys() as $field) {
 
-            foreach ($errors->get($field) as $message) {
+                foreach ($errors->get($field) as $message) {
 
-                $data['errors'][] = [ 'status' => $httpStatusCode, 'code' => $errorCode, 'title' =>  'Validation Fail', 'detail' => $message, 'meta' => ['field' => $field] ];
+                    $data['errors'][] = [ 'status' => $httpStatusCode, 'code' => $errorCode, 'title' =>  'Validation Fail', 'detail' => $message, 'meta' => ['field' => $field] ];
+
+                }
 
             }
-
         }
 
         parent::__construct($data, $httpStatusCode);


### PR DESCRIPTION
MultiErrorResponse - Supports error output with multiple errors
Exception\Validation - Excepts Laravel messagebag of validation fails

Models simply overload the getValidationRules to return a ruleset array (see http://laravel.com/docs/5.0/validation)

An example validation failure might look like:

```
{
   "errors":[
      {
         "status":400,
         "code":1040,
         "title":"Validation Fail",
         "detail":"The price must be a number.",
         "meta":{
            "field":"price"
         }
      },
      {
         "status":400,
         "code":1040,
         "title":"Validation Fail",
         "detail":"The ingredients field is required.",
         "meta":{
            "field":"ingredients"
         }
      }
   ]
}
```
