### PR TITLE
handler: fix referece to constant

### DIFF
--- a/src/EchoIt/JsonApi/Handler.php
+++ b/src/EchoIt/JsonApi/Handler.php
@@ -571,7 +571,7 @@ abstract class Handler
         if (!$model->save()) {
             throw new Exception(
                 'An unknown error occurred',
-                static::ERROR_SCOPE | static::ERROR_UNKNOWN,
+                static::ERROR_SCOPE | static::ERROR_UNKNOWN_ID,
                 BaseResponse::HTTP_INTERNAL_SERVER_ERROR
             );
         }
@@ -614,7 +614,7 @@ abstract class Handler
         if (!$model->save()) {
             throw new Exception(
                 'An unknown error occurred',
-                static::ERROR_SCOPE | static::ERROR_UNKNOWN,
+                static::ERROR_SCOPE | static::ERROR_UNKNOWN_ID,
                 BaseResponse::HTTP_INTERNAL_SERVER_ERROR
             );
         }


### PR DESCRIPTION
There's no constant named `ERROR_UNKNOWN`. Comparing
to other code fragments it seems this should be `.._ID`
