### PR TITLE
errors: ensure response matches jsonapi spec

### DIFF
--- a/src/EchoIt/JsonApi/ErrorResponse.php
+++ b/src/EchoIt/JsonApi/ErrorResponse.php
@@ -20,7 +20,11 @@ class ErrorResponse extends JsonResponse
     {
         $data = [
             'errors' => [ array_merge(
-                [ 'status' => $httpStatusCode, 'code' => $errorCode, 'title' => $errorTitle ],
+                [
+                    'status' => (string) $httpStatusCode,
+                    'code'   => (string) $errorCode,
+                    'title'  => (string) $errorTitle
+                ],
                 $additionalAttrs
             ) ]
         ];

--- a/src/EchoIt/JsonApi/MultiErrorResponse.php
+++ b/src/EchoIt/JsonApi/MultiErrorResponse.php
@@ -27,7 +27,15 @@ class MultiErrorResponse extends JsonResponse
 
                 foreach ($errors->get($field) as $message) {
 
-                    $data['errors'][] = [ 'status' => $httpStatusCode, 'code' => $errorCode, 'title' =>  'Validation Fail', 'detail' => $message, 'meta' => ['field' => $field] ];
+                    $data['errors'][] = [
+                        'status' => (string) $httpStatusCode,
+                        'code'   => (string) $errorCode,
+                        'title'  => 'Validation Fail',
+                        'detail' => (string) $message,
+                        'meta' => [
+                          'field' => $field
+                        ]
+                    ];
 
                 }
 


### PR DESCRIPTION
Per http://jsonapi.org/format/1.0/#errors 'status' and 'code' must be of
type string, if present.

For completeness I added casts for 'detail' and 'title' too, just in
case someone would pass an integer at a point.

This allows validating the response with e.g. http://jsonapi.org/faq/#is-there-a-json-schema-describing-json-api successfully.
