### PR TITLE
travis: bump minimum PHP version to 5.5 & fix tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.4
+  - 5.5
 
 before_script:
   - composer install
 
-script: vendor/bin/phing
+script: phpunit

--- a/tests/ErrorResponseTest.php
+++ b/tests/ErrorResponseTest.php
@@ -19,19 +19,21 @@ class ErrorResponseTest extends PHPUnit_Framework_TestCase
     public function testResponseBody()
     {
         $res = new ErrorResponse(404, 100, 'An error occurred');
-        $this->assertEquals('{"errors":[{"status":404,"code":100,"title":"An error occurred"}]}', $res->getContent());
+        $this->assertEquals('{"errors":[{"status":"404","code":"100","title":"An error occurred"}]}', $res->getContent());
         $this->assertJsonapiValid($res->getData());
     }
 
     public function testResponseWithAdditionalAttrs()
     {
         $res = new ErrorResponse(404, 100, 'An error occurred', [
-            'stacktrace' => [
-                'line' => 100,
-                'file' => 'script.php'
-            ]
+            'meta' => [
+                'stacktrace' => [
+                    'line' => 100,
+                    'file' => 'script.php'
+                ],
+            ],
         ]);
-        $this->assertEquals('{"errors":[{"status":404,"code":100,"title":"An error occurred","stacktrace":{"line":100,"file":"script.php"}}]}', $res->getContent());
+        $this->assertEquals('{"errors":[{"status":"404","code":"100","title":"An error occurred","meta":{"stacktrace":{"line":100,"file":"script.php"}}}]}', $res->getContent());
         $this->assertJsonapiValid($res->getData());
     }
 }


### PR DESCRIPTION
Required by some of the composer dependencies, e.g.
illuminate/database and needed adaption of existing
tests due jsonapi schema validation.

---

Let's see if this pleases Travis!
