### PR TITLE
Per jsonapi 1.0, id is always supposed to be string

### DIFF
--- a/src/EchoIt/JsonApi/Model.php
+++ b/src/EchoIt/JsonApi/Model.php
@@ -195,12 +195,12 @@ class Model extends \Eloquent
             }
 
             if ($value instanceof BaseModel) {
-                $relations[$relation] = array('linkage' => array('id' => $value->getKey(), 'type' => $value->getResourceType()));
+                $relations[$relation] = array('linkage' => array('id' => (string)$value->getKey(), 'type' => $value->getResourceType()));
             } elseif ($value instanceof Collection) {
                 $relation = \str_plural($relation);
                 $items = ['linkage' => []];
                 foreach ($value as $item) {
-                    $items['linkage'][] = array('id' => $item->getKey(), 'type' => $item->getResourceType());
+                    $items['linkage'][] = array('id' => (string)$item->getKey(), 'type' => $item->getResourceType());
                 }
                 $relations[$relation] = $items;
             }
@@ -216,7 +216,7 @@ class Model extends \Eloquent
         unset($model_attributes[$this->primaryKey]);
 
         $attributes = [
-            'id'         => $this->getKey(),
+            'id'         => (string)$this->getKey(),
             'type'       => $this->getResourceType(),
             'attributes' => $model_attributes
         ];


### PR DESCRIPTION
See http://jsonapi.org/format/1.0/#document-resource-objects : 

> Every resource object MUST contain an id member and a type member. The values of the id and type members MUST be strings.
