### PR TITLE
Change "details" to "detail"

### DIFF
--- a/src/EchoIt/JsonApi/Handler.php
+++ b/src/EchoIt/JsonApi/Handler.php
@@ -527,7 +527,7 @@ abstract class Handler
                 'Database Request Failed',
                 static::ERROR_SCOPE | static::ERROR_UNKNOWN_ID,
                 BaseResponse::HTTP_INTERNAL_SERVER_ERROR,
-                array('details' => $e->getMessage())
+                array('detail' => $e->getMessage())
             );
         }
         return $results;


### PR DESCRIPTION
According to http://jsonapi.org/format/1.0/#errors it must be `detail`
