### PR TITLE
Adjusted sorting in handler to match jsonapi.org spec

### DIFF
--- a/src/EchoIt/JsonApi/Handler.php
+++ b/src/EchoIt/JsonApi/Handler.php
@@ -384,19 +384,13 @@ abstract class Handler
     protected function handleSortRequest($cols, $model)
     {
         foreach ($cols as $col) {
-            $directionSymbol = substr($col, 0, 1);
-            if ($directionSymbol === "+" || substr($col, 0, 3) === '%2B') {
-                $dir = 'asc';
-            } elseif ($directionSymbol === "-") {
+            $dir = 'asc';
+
+            if (substr($col, 0, 1) == '-') {
                 $dir = 'desc';
-            } else {
-                throw new Exception(
-                    'Sort direction not specified but is required. Expecting "+" or "-".',
-                    static::ERROR_SCOPE | static::ERROR_UNKNOWN_ID,
-                    BaseResponse::HTTP_BAD_REQUEST
-                );
+                $col = substr($col, 1);
             }
-            $col = substr($col, 1);
+
             $model = $model->orderBy($col, $dir);
         }
         return $model;


### PR DESCRIPTION
According to the jsonapi.org spec you specify a list of columns you wish to sort by. By default all columns are sorted Ascending, however any columns prefixed by a hyphen (-) are sorted Descending.

There is no mention of a plus (+) prefix in the current spec. I'm assuming this was in a previous draft of the spec. This change removes the plus (+) prefix feature in favour of the Ascending by default rule.

http://jsonapi.org/format/#fetching-sorting
