### PR TITLE
model: don't reference facades but use the classes directly

### DIFF
--- a/src/EchoIt/JsonApi/Model.php
+++ b/src/EchoIt/JsonApi/Model.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot as Pivot;
  *
  * @author Ronni Egeriis Persson <ronni@egeriis.me>
  */
-class Model extends \Eloquent
+class Model extends \Illuminate\Database\Eloquent\Model
 {
     /**
      * Let's guard these fields per default


### PR DESCRIPTION
I need to use static references to a model (e.g. `Model::SOME_CONSTANT`) **before** the application is appropriately set up (e.g. during configuration options).

But this is currently not possible, because `\Eloquent` refers to the facade which are not set up at this point and results in `PHP Fatal error:  Class 'Eloquent' not found in /vendor/echo-it/laravel-jsonapi/src/EchoIt/JsonApi/Model.php on line 15`
